### PR TITLE
REVIEW - [NA-000] lambda-from-sqs forwards sqs_trigger.function_response_types variable

### DIFF
--- a/terraspace/app/modules/lambda-from-sqs/main.tf
+++ b/terraspace/app/modules/lambda-from-sqs/main.tf
@@ -2,7 +2,7 @@ resource "aws_lambda_event_source_mapping" "event_triggers" {
   event_source_arn                   = var.sqs_trigger.arn
   enabled                            = true
   function_name                      = aws_lambda_function.lambda.arn
-  function_response_types            = var.sqs_trigger.function_response_types
+  function_response_types            = var.sqs_trigger_function_response_types
   batch_size                         = var.sqs_trigger.batch_size
   maximum_batching_window_in_seconds = var.sqs_trigger.maximum_batching_window_in_seconds
 }

--- a/terraspace/app/modules/lambda-from-sqs/main.tf
+++ b/terraspace/app/modules/lambda-from-sqs/main.tf
@@ -2,6 +2,7 @@ resource "aws_lambda_event_source_mapping" "event_triggers" {
   event_source_arn                   = var.sqs_trigger.arn
   enabled                            = true
   function_name                      = aws_lambda_function.lambda.arn
+  function_response_types            = var.sqs_trigger.function_response_types
   batch_size                         = var.sqs_trigger.batch_size
   maximum_batching_window_in_seconds = var.sqs_trigger.maximum_batching_window_in_seconds
 }

--- a/terraspace/app/modules/lambda-from-sqs/variables.tf
+++ b/terraspace/app/modules/lambda-from-sqs/variables.tf
@@ -8,6 +8,7 @@ variable "sqs_trigger" {
 
 variable "sqs_trigger_function_response_types" {
   type                             = list(string)
+  default                          = null
   nullable                         = true
 }
 

--- a/terraspace/app/modules/lambda-from-sqs/variables.tf
+++ b/terraspace/app/modules/lambda-from-sqs/variables.tf
@@ -3,9 +3,9 @@ variable "sqs_trigger" {
     arn                                = string
     batch_size                         = number
     maximum_batching_window_in_seconds = number
+    function_response_types            = "ReportBatchItemFailures"
   })
 }
-
 
 variable "lambda" {
   type = object({

--- a/terraspace/app/modules/lambda-from-sqs/variables.tf
+++ b/terraspace/app/modules/lambda-from-sqs/variables.tf
@@ -3,8 +3,12 @@ variable "sqs_trigger" {
     arn                                = string
     batch_size                         = number
     maximum_batching_window_in_seconds = number
-    function_response_types            = "ReportBatchItemFailures"
   })
+}
+
+variable "sqs_trigger_function_response_types" {
+  type                             = list(string)
+  nullable                         = true
 }
 
 variable "lambda" {

--- a/terraspace/app/stacks/event/main.tf
+++ b/terraspace/app/stacks/event/main.tf
@@ -42,6 +42,7 @@ module "event_delivery_lambda_from_sqs" {
     arn                                = aws_sqs_queue.event_delivery_queue.arn
     batch_size                         = var.batch_size
     maximum_batching_window_in_seconds = 30
+    function_response_types            = "ReportBatchItemFailures"
   }
 
   lambda = {

--- a/terraspace/app/stacks/event/main.tf
+++ b/terraspace/app/stacks/event/main.tf
@@ -42,8 +42,8 @@ module "event_delivery_lambda_from_sqs" {
     arn                                = aws_sqs_queue.event_delivery_queue.arn
     batch_size                         = var.batch_size
     maximum_batching_window_in_seconds = 30
-    function_response_types            = "ReportBatchItemFailures"
   }
+  sqs_trigger_function_response_types  = ["ReportBatchItemFailures"]
 
   lambda = {
     name                           = var.event_delivery_lambda.name

--- a/terraspace/app/stacks/event/variables.tf
+++ b/terraspace/app/stacks/event/variables.tf
@@ -49,5 +49,6 @@ variable "batch_size" {
 
 variable "event_target" {
   type        = string
+  default     = ""
   description = "EVENT_TARGET environment variable value for event delivery lambda"
 }


### PR DESCRIPTION
Motivation:
* https://github.com/elastic-ipfs/infrastructure/issues/154

Questions:
* I don't see any lint or sec failures that seem specific to this change
* I'm assuming that uses of the lambda-from-sqs module that *dont* specify a `var.sqs_trigger.function_response_types` will just get a `null` passed through? hope so. I tried to use [this optional feature](https://www.terraform.io/language/expressions/type-constraints#experimental-optional-object-type-attributes) but the gh actions didn't seem to like that syntax (I force pushed over the top, oops)
* I noticed even when the lint script fails, the gh action check still succeeds due to `continue-on-error: true` [here](https://github.com/elastic-ipfs/infrastructure/blob/main/.github/workflows/terraspace.yaml#L231). Are we sure we don't want failed lints to result in failed CI? @francardoso93 