### PR TITLE
REVIEW - [NA-000] unset event_target for staging/prod event stacks

### DIFF
--- a/terraspace/app/stacks/event/tfvars/us-west-2/prod.tfvars
+++ b/terraspace/app/stacks/event/tfvars/us-west-2/prod.tfvars
@@ -1,1 +1,0 @@
-event_target="https://indexer-metrics-collector-production.protocol-labs.workers.dev/events"

--- a/terraspace/app/stacks/event/tfvars/us-west-2/staging.tfvars
+++ b/terraspace/app/stacks/event/tfvars/us-west-2/staging.tfvars
@@ -1,1 +1,0 @@
-event_target="https://indexer-metrics-collector-staging.protocol-labs.workers.dev/events"

--- a/terraspace/app/stacks/event/variables.tf
+++ b/terraspace/app/stacks/event/variables.tf
@@ -49,7 +49,7 @@ variable "batch_size" {
 
 variable "event_target" {
   type        = string
-  default     = ""
+  nullable    = true
   description = "EVENT_TARGET environment variable value for event delivery lambda"
 }
 

--- a/terraspace/app/stacks/event/variables.tf
+++ b/terraspace/app/stacks/event/variables.tf
@@ -50,6 +50,7 @@ variable "batch_size" {
 variable "event_target" {
   type        = string
   nullable    = true
+  default     = null
   description = "EVENT_TARGET environment variable value for event delivery lambda"
 }
 


### PR DESCRIPTION
Motivation:
* https://github.com/elastic-ipfs/infrastructure/issues/160
* the goal is to stop passing EVENT_TARGET env var to the event-delivery-lambda in staging/production . We want it unset so the app uses EVENT_TARGET_CREDENTIALS_SECRET_NAME instead