### PR TITLE
[REVIEW] - [NA-000] - Support ArgoCD Rollouts Dashboard being exposed publicly

### DIFF
--- a/terraspace/app/stacks/peer-kubernetes-components/helm.tf
+++ b/terraspace/app/stacks/peer-kubernetes-components/helm.tf
@@ -73,4 +73,14 @@ resource "helm_release" "argocd_rollouts" {
     name  = "dashboard.enabled"
     value = true
   }
+
+  set {
+    name = "dashboard.service.type"
+    value = var.argocd_rollouts_dashboard_service_type
+  }
+
+  set {
+    name  = "dashboard.service.loadBalancerSourceRanges"
+    value = "{${join(",", var.argocd_rollouts_dashboard_allowed_ips)}}"
+  }
 }

--- a/terraspace/app/stacks/peer-kubernetes-components/variables.tf
+++ b/terraspace/app/stacks/peer-kubernetes-components/variables.tf
@@ -75,6 +75,23 @@ variable "argocd_rollouts_version" {
   description = "Version for argocd rollouts operator"
 }
 
+variable "argocd_rollouts_dashboard_service_type" {
+  type        = string
+  description = "`LoadBalancer` if you wish to expose the dashboard publicly, `ClusterIP` otherwise"
+  default     = "ClusterIP"
+
+  validation {
+    condition     = can(regex("^ClusterIP|^LoadBalancer$", var.argocd_rollouts_dashboard_service_type))
+    error_message = "Err: invalid service type."
+  }
+}
+
+variable "argocd_rollouts_dashboard_allowed_ips" {
+  type = list(string)
+  description = "List of Client CIDRs to permit access to the dashboard"
+  default = []
+}
+
 variable "cluster_autoscaler_role_name" {
   type        = string
   description = "Name for cluster autoscaler role"


### PR DESCRIPTION
By default, the dashboard is only available internally. The changes in this PR add support for us to make it available publicly if the need arises