### PR TITLE
chore: add more subnets

### DIFF
--- a/terraspace/app/stacks/peer/tfvars/us-west-2/prod.tfvars
+++ b/terraspace/app/stacks/peer/tfvars/us-west-2/prod.tfvars
@@ -1,8 +1,8 @@
 vpc = {
   name                 = "test-ipfs-peer-subsys"
   cidr                 = "10.0.0.0/16"
-  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
-  public_subnets       = ["10.0.5.0/24", "10.0.6.0/24", "10.0.7.0/24"]
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24", "10.0.105.0/24"]
+  public_subnets       = ["10.0.5.0/24", "10.0.6.0/24", "10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24"]
   enable_nat_gateway   = true
   single_nat_gateway   = true
   enable_dns_hostnames = true


### PR DESCRIPTION
This PR adds more subnets, which allows us to update cluster endpoint access and give the dev team access to the EKS cluster.

Due to using consecutive numbers in existing private and public subnets I've bumped the next private subnet to `105`. IDK, I wanted 5, but it was not available so I added 100.