### PR TITLE
chore: try arm based instances for e-ipfs bitswap peer

### DIFF
--- a/.github/workflows/pr-comment-terraspace.yaml
+++ b/.github/workflows/pr-comment-terraspace.yaml
@@ -149,7 +149,7 @@ jobs:
           res=$(curl "https://api.github.com/repos/${{ github.repository }}/pulls/${pr_number}/reviews?per_page=100" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H 'Content-Type: application/json')
           echo "Res: $res"
           # shellcheck disable=SC2086
-          echo "approval_state=$(echo $res | jq '.[] | select(.state=="APPROVED").state' | sed 's/"//g')" >> "$GITHUB_OUTPUT"
+          echo "approval_state=$(echo $res | jq '.[] | select(.state=="APPROVED").state' | sed 's/"//g' | head -n 1)" >> "$GITHUB_OUTPUT"
 
       - name: Display Approval Result
         env:

--- a/terraspace/app/stacks/peer/main.tf
+++ b/terraspace/app/stacks/peer/main.tf
@@ -77,7 +77,8 @@ module "eks" {
   cluster_endpoint_public_access_cidrs = [
     "62.232.226.28/32", # alan
     "86.183.170.43/32", # alan
-    "86.56.31.53/32", # vasco
+    "86.56.31.53/32",   # vasco
+    "91.135.10.211/32"  # oli
   ]
 
   eks_managed_node_groups = { # Needed for CoreDNS (https://docs.aws.amazon.com/eks/latest/userguide/fargate-getting-started.html)

--- a/terraspace/app/stacks/peer/main.tf
+++ b/terraspace/app/stacks/peer/main.tf
@@ -87,6 +87,7 @@ module "eks" {
       min_size     = var.eks.eks_managed_node_groups.min_size
       max_size     = var.eks.eks_managed_node_groups.max_size
       instance_types = var.eks.eks_managed_node_groups.instance_types
+      ami_type     = var.eks.eks_managed_node_groups.ami_type
       k8s_labels = {
         workerType = "managed_ec2_node_groups"
       }

--- a/terraspace/app/stacks/peer/peer.md
+++ b/terraspace/app/stacks/peer/peer.md
@@ -95,6 +95,7 @@ object({
       min_size       = number
       max_size       = number
       instance_types = list(string)
+      ami_type       = string
     })
   })
 ```

--- a/terraspace/app/stacks/peer/tfvars/base.tfvars
+++ b/terraspace/app/stacks/peer/tfvars/base.tfvars
@@ -10,6 +10,7 @@ eks = {
     min_size       = 2
     max_size       = 5
     instance_types = ["c6g.2xlarge"]
+    ami_type       = "AL2_ARM_64"
   }
 }
 config_table = {

--- a/terraspace/app/stacks/peer/tfvars/base.tfvars
+++ b/terraspace/app/stacks/peer/tfvars/base.tfvars
@@ -9,7 +9,7 @@ eks = {
     desired_size   = 2
     min_size       = 2
     max_size       = 5
-    instance_types = ["c6i.2xlarge"]
+    instance_types = ["c6g.2xlarge"]
   }
 }
 config_table = {

--- a/terraspace/app/stacks/peer/tfvars/us-west-2/prod.tfvars
+++ b/terraspace/app/stacks/peer/tfvars/us-west-2/prod.tfvars
@@ -16,6 +16,7 @@ eks = {
     min_size       = 2
     max_size       = 50
     instance_types = ["c6g.2xlarge"]
+    ami_type       = "AL2_ARM_64"
   }
 }
 account_id = "<%= expansion(':ACCOUNT') %>"

--- a/terraspace/app/stacks/peer/tfvars/us-west-2/prod.tfvars
+++ b/terraspace/app/stacks/peer/tfvars/us-west-2/prod.tfvars
@@ -12,9 +12,9 @@ eks = {
   version = 1.23
   eks_managed_node_groups = {
     name           = "test-ipfs-peer-subsys"
-    desired_size   = 20
+    desired_size   = 12
     min_size       = 2
-    max_size       = 22
+    max_size       = 18
     instance_types = ["c6g.2xlarge"]
     ami_type       = "AL2_ARM_64"
   }

--- a/terraspace/app/stacks/peer/tfvars/us-west-2/prod.tfvars
+++ b/terraspace/app/stacks/peer/tfvars/us-west-2/prod.tfvars
@@ -15,7 +15,7 @@ eks = {
     desired_size   = 2
     min_size       = 2
     max_size       = 50
-    instance_types = ["c6i.2xlarge"]
+    instance_types = ["c6g.2xlarge"]
   }
 }
 account_id = "<%= expansion(':ACCOUNT') %>"

--- a/terraspace/app/stacks/peer/variables.tf
+++ b/terraspace/app/stacks/peer/variables.tf
@@ -21,6 +21,7 @@ variable "eks" {
       min_size       = number
       max_size       = number
       instance_types = list(string)
+      ami_type       = string
     })
   })
   description = "EKS cluster"


### PR DESCRIPTION
This updates the default bitswap peer eks instance type to `c6g.2xlarge` based on arm

Deployment will go to dev & staging first, so we can test this out before committing.

wip: https://github.com/elastic-ipfs/elastic-ipfs/issues/27

| arch | class | vcpu | ram | storage | egress bandwidth | EBS bandwidth
|------|------|------|-----|---------|-------------------|----------------
| arm  | `c6g.2xlarge` |	8 | 16 | EBS-Only | Up to 10 Gbps | Up to 4,750 Mbps
| x86  | `c6i.2xlarge` | 8 | 16 | EBS-Only | Up to 12.5 Gbps | Up to 10 Gps

source: https://aws.amazon.com/ec2/instance-types/

License: MIT