### PR TITLE
fix: disable point in time recovery for dynamodb tables

### DIFF
--- a/terraspace/app/modules/dynamodb/main.tf
+++ b/terraspace/app/modules/dynamodb/main.tf
@@ -9,6 +9,7 @@ terraform {
   required_version = ">= 1.0.0"
 }
 
+#tfsec:ignore:aws-dynamodb-enable-recovery
 resource "aws_dynamodb_table" "blocks_table" {
   name         = var.blocks_table.name
   billing_mode = "PAY_PER_REQUEST"
@@ -23,6 +24,7 @@ resource "aws_dynamodb_table" "blocks_table" {
   }
 }
 
+#tfsec:ignore:aws-dynamodb-enable-recovery
 resource "aws_dynamodb_table" "cars_table" {
   name         = var.cars_table.name
   billing_mode = "PAY_PER_REQUEST"

--- a/terraspace/app/modules/dynamodb/main.tf
+++ b/terraspace/app/modules/dynamodb/main.tf
@@ -19,7 +19,7 @@ resource "aws_dynamodb_table" "blocks_table" {
   }
 
   point_in_time_recovery {
-    enabled = true
+    enabled = false
   }
 }
 
@@ -32,6 +32,6 @@ resource "aws_dynamodb_table" "cars_table" {
     type = "S"
   }
   point_in_time_recovery {
-    enabled = true
+    enabled = false
   }
 }

--- a/terraspace/app/stacks/peer/main.tf
+++ b/terraspace/app/stacks/peer/main.tf
@@ -174,6 +174,7 @@ resource "aws_security_group_rule" "dns_ingress_udp" {
   security_group_id        = module.eks.node_security_group_id
 }
 
+#tfsec:ignore:aws-dynamodb-enable-recovery
 resource "aws_dynamodb_table" "config_table" {
   name         = var.config_table.name
   billing_mode = "PAY_PER_REQUEST"

--- a/terraspace/app/stacks/peer/main.tf
+++ b/terraspace/app/stacks/peer/main.tf
@@ -184,6 +184,6 @@ resource "aws_dynamodb_table" "config_table" {
   }
 
   point_in_time_recovery {
-    enabled = true
+    enabled = false
   }
 }

--- a/terraspace/app/stacks/shared/main.tf
+++ b/terraspace/app/stacks/shared/main.tf
@@ -55,6 +55,7 @@ resource "aws_sqs_queue" "multihashes_topic_dlq" {
   visibility_timeout_seconds = 300
 }
 
+#tfsec:ignore:aws-dynamodb-enable-recovery
 resource "aws_dynamodb_table" "v1_cars_table" {
   name         = var.v1_cars_table.name
   billing_mode = "PAY_PER_REQUEST"
@@ -68,6 +69,7 @@ resource "aws_dynamodb_table" "v1_cars_table" {
   }
 }
 
+#tfsec:ignore:aws-dynamodb-enable-recovery
 resource "aws_dynamodb_table" "v1_blocks_table" {
   name         = var.v1_blocks_table.name
   billing_mode = "PAY_PER_REQUEST"
@@ -82,6 +84,7 @@ resource "aws_dynamodb_table" "v1_blocks_table" {
   }
 }
 
+#tfsec:ignore:aws-dynamodb-enable-recovery
 resource "aws_dynamodb_table" "v1_link_table" {
   name         = var.v1_link_table.name
   billing_mode = "PAY_PER_REQUEST"

--- a/terraspace/app/stacks/shared/main.tf
+++ b/terraspace/app/stacks/shared/main.tf
@@ -64,7 +64,7 @@ resource "aws_dynamodb_table" "v1_cars_table" {
     type = "S"
   }
   point_in_time_recovery {
-    enabled = true
+    enabled = false
   }
 }
 
@@ -78,7 +78,7 @@ resource "aws_dynamodb_table" "v1_blocks_table" {
   }
 
   point_in_time_recovery {
-    enabled = true
+    enabled = false
   }
 }
 
@@ -97,7 +97,7 @@ resource "aws_dynamodb_table" "v1_link_table" {
   }
 
   point_in_time_recovery {
-    enabled = true
+    enabled = false
   }
 }
 


### PR DESCRIPTION
This PR removes point in time recovery for dynamodb tables here per https://github.com/web3-storage/secrets/issues/5

Once this releases, we should check https://us-west-2.console.aws.amazon.com/dynamodbv2/home?region=us-west-2#table?name=prod-ep-v1-cars&tab=backups  to guarantee cloudformation does it. Otherwise, then we can disable it manually in the console

cc @travis (cannot ask you review in this org...)