### PR TITLE
fix: add subnets to allow 20+ nodes to run

### DIFF
--- a/terraspace/app/stacks/peer/tfvars/us-west-2/prod.tfvars
+++ b/terraspace/app/stacks/peer/tfvars/us-west-2/prod.tfvars
@@ -1,8 +1,8 @@
 vpc = {
   name                 = "test-ipfs-peer-subsys"
   cidr                 = "10.0.0.0/16"
-  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24", "10.0.105.0/24"]
-  public_subnets       = ["10.0.5.0/24", "10.0.6.0/24", "10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24"]
+  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24", "10.0.105.0/24", "10.0.106.0/24"]
+  public_subnets       = ["10.0.5.0/24", "10.0.6.0/24", "10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24", "10.0.10.0/24"]
   enable_nat_gateway   = true
   single_nat_gateway   = true
   enable_dns_hostnames = true
@@ -12,9 +12,9 @@ eks = {
   version = 1.23
   eks_managed_node_groups = {
     name           = "test-ipfs-peer-subsys"
-    desired_size   = 2
+    desired_size   = 20
     min_size       = 2
-    max_size       = 50
+    max_size       = 22
     instance_types = ["c6i.2xlarge"]
   }
 }


### PR DESCRIPTION
prod is "DEGREADED" with only 19 nodes coming up due to

> Amazon AutoScaling was unable to launch instances because there are not enough free addresses in the subnet associated with your AutoScaling group(s).

so we add more subnets here.

Also prod is running with `desired_size: 20` so we up that here to match reality... and we dial down max_size as we dont want any suprise spikes in billing.

License: MIT