### PR TITLE
fix: provide more subnets to eks

### DIFF
--- a/terraspace/app/stacks/peer/main.tf
+++ b/terraspace/app/stacks/peer/main.tf
@@ -70,14 +70,15 @@ module "eks" {
   cluster_endpoint_private_access    = true
   cluster_endpoint_public_access     = true
   vpc_id                             = module.vpc.vpc_id
-  subnet_ids                         = [module.vpc.private_subnets[0], module.vpc.private_subnets[1]]
+  subnet_ids                         = [module.vpc.private_subnets[0], module.vpc.private_subnets[1], module.vpc.private_subnets[2]]
   enable_irsa                        = true # To be able to access AWS services from PODs  
   cluster_security_group_description = "EKS cluster security group - Control Plane"
 
   cluster_endpoint_public_access_cidrs = [
     "62.232.226.28/32", # alan
     "86.183.170.43/32", # alan
-    "86.56.31.53/32", # vasco
+    "86.56.31.53/32",   # vasco
+    "91.135.10.211/32"  # oli
   ]
 
   eks_managed_node_groups = { # Needed for CoreDNS (https://docs.aws.amazon.com/eks/latest/userguide/fargate-getting-started.html)


### PR DESCRIPTION
attempting to fix:
> Error: error updating EKS Cluster (test-ipfs-peer-subsys) VPC config: InvalidRequestException: Provided subnets subnet-040a1f0013274c2b0 Free IPs: 0 subnet-0af91474429282c3d Free IPs: 0 , need at least 5 IPs in each subnet to be free for this operation

where those 2 subnets appear to be the 2 subnets provided here, and yes, neither has a spare ip. While the other subets have loads to spare, so maybe give another one to eks IDK.

License: MIT