### PR TITLE
fix: update argo-cd to v2.5 for arm support

### DIFF
--- a/terraspace/app/stacks/peer-kubernetes-components/helm.tf
+++ b/terraspace/app/stacks/peer-kubernetes-components/helm.tf
@@ -26,6 +26,7 @@ resource "helm_release" "metric_server" {
 resource "helm_release" "argocd_apps" {
   name             = "argocd-apps"
   chart            = "./helm/argocd-apps"
+  version          = "0.2.0"
   namespace        = "argocd"
   create_namespace = true
 

--- a/terraspace/app/stacks/peer-kubernetes-components/helm/argocd-apps/Chart.lock
+++ b/terraspace/app/stacks/peer-kubernetes-components/helm/argocd-apps/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
-  version: 2.2.16
-digest: sha256:98b53505f8884cf8b2ea423186f1b227636bb99d609c439b726657b4c055afff
-generated: "2022-02-07T15:30:47.444286145-03:00"
+  version: 2.5.4
+digest: sha256:284fa868a532c4e0e39c2987ff3af1ad28f4237dad1bf4137b1988f99de708dd
+generated: "2023-06-08T20:43:55.839315+01:00"

--- a/terraspace/app/stacks/peer-kubernetes-components/helm/argocd-apps/Chart.lock
+++ b/terraspace/app/stacks/peer-kubernetes-components/helm/argocd-apps/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
-  version: 2.5.4
-digest: sha256:284fa868a532c4e0e39c2987ff3af1ad28f4237dad1bf4137b1988f99de708dd
-generated: "2023-06-08T20:43:55.839315+01:00"
+  version: 5.7.0
+digest: sha256:7bde2a8041ca75b95fb96c1a1965ade363909de6ba78d6253d587905b6ef0d4a
+generated: "2023-06-08T21:18:09.071913+01:00"

--- a/terraspace/app/stacks/peer-kubernetes-components/helm/argocd-apps/Chart.yaml
+++ b/terraspace/app/stacks/peer-kubernetes-components/helm/argocd-apps/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: argocd-apps
 description: A Helm chart for installing ArgoCD and a set of applications
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 dependencies:
 - name: argo-cd
-  version: "~> 2.5.17"
+  version: "~> 2.5"
   repository: "https://argoproj.github.io/argo-helm"

--- a/terraspace/app/stacks/peer-kubernetes-components/helm/argocd-apps/Chart.yaml
+++ b/terraspace/app/stacks/peer-kubernetes-components/helm/argocd-apps/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.1.0
 appVersion: "0.1.0"
 dependencies:
 - name: argo-cd
-  version: "~> 2.2.5"
+  version: "~> 2.5.17"
   repository: "https://argoproj.github.io/argo-helm"

--- a/terraspace/app/stacks/peer-kubernetes-components/helm/argocd-apps/Chart.yaml
+++ b/terraspace/app/stacks/peer-kubernetes-components/helm/argocd-apps/Chart.yaml
@@ -6,5 +6,5 @@ version: 0.2.0
 appVersion: "0.2.0"
 dependencies:
 - name: argo-cd
-  version: "~> 2.5"
+  version: "~> 5.7"
   repository: "https://argoproj.github.io/argo-helm"

--- a/terraspace/app/stacks/peer-kubernetes-components/helm/update.sh
+++ b/terraspace/app/stacks/peer-kubernetes-components/helm/update.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+YOUR_ARGOCD_NAMESPACE="argocd" # e.g. argo-cd
+YOUR_ARGOCD_RELEASENAME="argocd-apps" # e.g. argo-cd
+
+for crd in "applications.argoproj.io" "applicationsets.argoproj.io" "argocdextensions.argoproj.io" "appprojects.argoproj.io"; do
+  kubectl label --overwrite crd $crd app.kubernetes.io/managed-by=Helm
+  kubectl annotate --overwrite crd $crd meta.helm.sh/release-namespace="$YOUR_ARGOCD_NAMESPACE"
+  kubectl annotate --overwrite crd $crd meta.helm.sh/release-name="$YOUR_ARGOCD_RELEASENAME"
+done

--- a/terraspace/app/stacks/peer-kubernetes-components/helm/update.sh
+++ b/terraspace/app/stacks/peer-kubernetes-components/helm/update.sh
@@ -8,3 +8,21 @@ for crd in "applications.argoproj.io" "applicationsets.argoproj.io" "argocdexten
   kubectl annotate --overwrite crd $crd meta.helm.sh/release-namespace="$YOUR_ARGOCD_NAMESPACE"
   kubectl annotate --overwrite crd $crd meta.helm.sh/release-name="$YOUR_ARGOCD_RELEASENAME"
 done
+
+for sa in "argocd-notifications-controller"; do
+  kubectl -n $YOUR_ARGOCD_NAMESPACE label --overwrite serviceaccount $sa app.kubernetes.io/managed-by=Helm
+  kubectl -n $YOUR_ARGOCD_NAMESPACE annotate --overwrite serviceaccount $sa meta.helm.sh/release-namespace="$YOUR_ARGOCD_NAMESPACE"
+  kubectl -n $YOUR_ARGOCD_NAMESPACE annotate --overwrite serviceaccount $sa meta.helm.sh/release-name="$YOUR_ARGOCD_RELEASENAME"
+done
+
+for sec in "argocd-notifications-secret"; do
+  kubectl -n $YOUR_ARGOCD_NAMESPACE label --overwrite secret $sec app.kubernetes.io/managed-by=Helm
+  kubectl -n $YOUR_ARGOCD_NAMESPACE annotate --overwrite secret $sec meta.helm.sh/release-namespace="$YOUR_ARGOCD_NAMESPACE"
+  kubectl -n $YOUR_ARGOCD_NAMESPACE annotate --overwrite secret $sec meta.helm.sh/release-name="$YOUR_ARGOCD_RELEASENAME"
+done
+
+for cm in "argocd-notifications-cm"; do
+  kubectl -n $YOUR_ARGOCD_NAMESPACE label --overwrite configmap $cm app.kubernetes.io/managed-by=Helm
+  kubectl -n $YOUR_ARGOCD_NAMESPACE annotate --overwrite configmap $cm meta.helm.sh/release-namespace="$YOUR_ARGOCD_NAMESPACE"
+  kubectl -n $YOUR_ARGOCD_NAMESPACE annotate --overwrite configmap $cm meta.helm.sh/release-name="$YOUR_ARGOCD_RELEASENAME"
+done

--- a/terraspace/app/stacks/peer-kubernetes-components/tfvars/base.tfvars
+++ b/terraspace/app/stacks/peer-kubernetes-components/tfvars/base.tfvars
@@ -30,6 +30,6 @@ cluster_autoscaler_version     = "9.9.2"
 cluster_autoscaler_role_name   = "<%= expansion(':ENV') %>-ep-eks-cluster-autoscaler"
 cluster_autoscaler_policy_name = "<%= expansion(':ENV') %>-ep-eks-cluster-autoscaler"
 metrics_server_version         = "6.2"
-argocd_rollouts_version        = "2.21.1"
+argocd_rollouts_version        = "2.31.0"
 bitswap_peer_deployment_branch = "HEAD"
 aws_certificate_arn            = <%= output('dns-certificate.aws_certificate_arn', mock: "") %>


### PR DESCRIPTION
the argocd pods are crashing as the older version is not built for arm.

We seem to be stuck with 20 bitswap peer pods, as that was the last config where argocd worked. I have not been able to scale up that number manually using kubectl.

Also the cluster autoscaler appears to be scaling the number of sever instances to the minimum number requires to fit the pods. we asked for 14 server instances but it scaled it down to 7. each bitswap peer asks for 4GB ram, and each instance has ~12GB available for bitswap pods.

So we can fit up to 3 bs pods per instance so it gives us 7 intances.

from the numbers I think we need to scale the number of bs pods back up to ~30. The cluster scaler should do it's thing and provision ~10 intances again.

BUT. We it seems we can't scale that number without fixing argocd. Note that there are 2 argo tools installed here "argo-cd" which I think controls the scaling of pods & "argo-rollouts" which controls canary deployments. (But argo-rollouts is confusingly labelled argocd-rollouts). That important note is that our "argo-rollouts" pods *are working* but our argo-cd pods are crash looping due to running an old version.

So we can rollout new versions of the container image but we seem to be unable to scale the number of the pods.



see: https://github.com/argoproj/argo-cd/issues/9121

License: MIT